### PR TITLE
perf: only test for protocol at beginning of id

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -94,7 +94,7 @@ export function resolveModuleURL<O extends ResolveOptions>(
   }
 
   // Skip if already has a protocol
-  if (/(node|data|http|https):/.test(id)) {
+  if (/^(?:node|data|http|https):/.test(id)) {
     return id;
   }
 


### PR DESCRIPTION
two small perf improvements:

1. only test for protocol at beginning of id, e.g. `/my/path/data:thing/` should not trigger early return
2. use non-capturing group