### PR TITLE
docs: tiny typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const { resolveModuleURL, resolveModulePath } = createResolver({
 
 ## Resolve cache
 
-To speedup resolution, resolved values (and errors) are globally cached with a unique key based on id and options.
+To speed up resolution, resolved values (and errors) are globally cached with a unique key based on id and options.
 
 **Example:** Invalidate all (global) cache entries (to support file-system changes).
 


### PR DESCRIPTION
I think here "Speedup" should be written as two words "speed up" when used as a verb phrase. 
