### PR TITLE
test: add failing test for missing subpath imports

### DIFF
--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -70,8 +70,8 @@ describe("resolveModuleURL", () => {
       from: import.meta.url,
       try: true,
     });
-    expect(resolved).toMatchInlineSnapshot()
-  })
+    expect(resolved).toMatchInlineSnapshot();
+  });
 
   it("resolves node built-ins", () => {
     expect(resolveModuleURL("node:fs")).toBe("node:fs");

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -65,7 +65,15 @@ describe("resolveModuleURL", () => {
     expect(fileURLToPath(resolved2)).match(/fixture[/\\]test.txt$/);
   });
 
-  it("resolves node built-ints", () => {
+  it("handles missing subpath imports", () => {
+    const resolved = resolveModuleURL("#build/auth.js", {
+      from: import.meta.url,
+      try: true,
+    });
+    expect(resolved).toMatchInlineSnapshot()
+  })
+
+  it("resolves node built-ins", () => {
     expect(resolveModuleURL("node:fs")).toBe("node:fs");
     expect(resolveModuleURL("fs")).toBe("node:fs");
     expect(resolveModuleURL("node:foo")).toBe("node:foo");


### PR DESCRIPTION
another issue discovered in https://github.com/nuxt/nuxt/actions/runs/13531822990/job/37815788093.