### PR TITLE
fix: resolve modules using full url

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -146,12 +146,12 @@ export function resolveModuleURL<O extends ResolveOptions>(
   const suffixes = options?.suffixes || [""];
   const extensions = options?.extensions ? ["", ...options.extensions] : [""];
   let resolved: URL | undefined;
-  for (const url of bases) {
+  for (const base of bases) {
     for (const suffix of suffixes) {
       for (const extension of extensions) {
         resolved = _tryModuleResolve(
-          _join(specifier || absolutePath, suffix) + extension,
-          url,
+          _join(specifier || url.href, suffix) + extension,
+          base,
           conditionsSet,
         );
         if (resolved) {

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -81,7 +81,7 @@ describe("resolveModuleURL", () => {
     expect(resolved).toMatchInlineSnapshot();
   });
 
-  it.todo("should resolve suffixes fully on windows", () => {
+  it("should resolve suffixes fully on windows", () => {
     const res = resolveModuleURL(
       fileURLToPath(new URL("fixture/foo", import.meta.url)),
       {

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -81,7 +81,7 @@ describe("resolveModuleURL", () => {
     expect(resolved).toMatchInlineSnapshot();
   });
 
-  it("should resolve suffixes fully on windows", () => {
+  it("should resolve suffixes to real file", () => {
     const res = resolveModuleURL(
       fileURLToPath(new URL("fixture/foo", import.meta.url)),
       {


### PR DESCRIPTION
When passing Windows absolute paths to the internal `moduleResolve`, it will return it as is without even trying to resolve.