### PR TITLE
fix: ensure no `//` in joined paths

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -313,7 +313,7 @@ function _join(a: string, b: string): string {
   if (!a || !b || b === "/") {
     return a;
   }
-  return a.replace(/\/$/, "") + "/" + b.replace(/^\//, "");
+  return (a.endsWith("/") ? a : a + "/") + (b.startsWith("/") ? b.slice(1) : b);
 }
 
 function _parseInput(

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -313,7 +313,7 @@ function _join(a: string, b: string): string {
   if (!a || !b || b === "/") {
     return a;
   }
-  return a.endsWith("/") ? a + b.replace(/^\//, '') : a + "/" + b.replace(/^\//, '');
+  return a.replace(/\/$/, "") + "/" + b.replace(/^\//, "");
 }
 
 function _parseInput(

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -313,7 +313,7 @@ function _join(a: string, b: string): string {
   if (!a || !b || b === "/") {
     return a;
   }
-  return a.endsWith("/") ? a + b : a + "/" + b;
+  return a.endsWith("/") ? a + b.replace(/^\//, '') : a + "/" + b.replace(/^\//, '');
 }
 
 function _parseInput(


### PR DESCRIPTION
otherwise suffix of `/something` can end up joined to a trailing slash with `//` which yields this deprecation warning from node:

```
[7:49:48 AM]  ERROR  (node:74938) [DEP0166] DeprecationWarning: Use of deprecated double slash resolving ".//module/index.vue" for module request ".//module/index.vue" matched to "./*" in the "exports" field module resolution of the package at /Users/daniel/code/nuxt/nuxt/packages/nuxt/node_modules/@nuxt/devtools/package.json imported from /Users/daniel/code/nuxt/nuxt/packages/nuxt/.
```

This happens for any package with a `./*` export pattern:

```json
  "exports": {
    ".": {
      "types": "./dist/module.d.mts",
      "import": "./dist/module.mjs"
    },
    "./types": {
      "types": "./dist/types.d.ts"
    },
    "./*": "./*"
  },
```