### PR TITLE
feat(resolveModulePath): normalize windows paths

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -323,9 +323,7 @@ function _join(a: string, b: string): string {
 }
 
 function _normalizeWinPath(path: string): string {
-  return path
-    .replace(/\\/g, "/")
-    .replace(/^[a-z]:\//, (r) => r.toUpperCase());
+  return path.replace(/\\/g, "/").replace(/^[a-z]:\//, (r) => r.toUpperCase());
 }
 
 function _parseInput(

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -207,7 +207,9 @@ export function resolveModulePath<O extends ResolveOptions>(
   options?: O,
 ): ResolveRes<O> {
   const resolved = resolveModuleURL(id, options);
-  return (resolved ? fileURLToPath(resolved) : undefined) as ResolveRes<O>;
+  return (
+    resolved ? _normalizeWinPath(fileURLToPath(resolved)) : undefined
+  ) as ResolveRes<O>;
 }
 
 export function createResolver(defaults?: ResolverOptions) {
@@ -314,6 +316,16 @@ function _join(a: string, b: string): string {
     return a;
   }
   return (a.endsWith("/") ? a : a + "/") + (b.startsWith("/") ? b.slice(1) : b);
+}
+
+function _normalizeWinPath(path: string): string {
+  // Platform specific path normalization to reduce runtime overhead
+  if (process.platform !== "win32") {
+    return path;
+  }
+  return path
+    .replace(/\\/g, "/")
+    .replace(/^[A-Za-z]:\//, (r) => r.toUpperCase());
 }
 
 function _parseInput(

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -6,7 +6,7 @@ import { moduleResolve } from "./internal/resolve.ts";
 
 const DEFAULT_CONDITIONS_SET = /* #__PURE__ */ new Set(["node", "import"]);
 
-const isWindows = /* #__PURE__ */ (() => process.platform !== "win32")();
+const isWindows = /* #__PURE__ */ (() => process.platform === "win32")();
 
 const NOT_FOUND_ERRORS = /* #__PURE__ */ new Set([
   "ERR_MODULE_NOT_FOUND",

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -325,7 +325,7 @@ function _join(a: string, b: string): string {
 function _normalizeWinPath(path: string): string {
   return path
     .replace(/\\/g, "/")
-    .replace(/^[A-Za-z]:\//, (r) => r.toUpperCase());
+    .replace(/^[a-z]:\//, (r) => r.toUpperCase());
 }
 
 function _parseInput(

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -92,26 +92,6 @@ describe("resolveModuleURL", () => {
     );
     expect(res).toMatch(/\.mjs$/);
   });
-
-  describe.runIf(isWindows)("windows", () => {
-    it("preserves casing", () => {
-      const DRIVE_LETTER_RE = /^\w(?=:)/;
-      const id = fileURLToPath(new URL("fixture/foo", import.meta.url));
-      const driveLetter = id.match(DRIVE_LETTER_RE)![0];
-      expect(driveLetter).toBe(driveLetter.toUpperCase());
-
-      const path = fileURLToPath(
-        resolveModuleURL(id, {
-          from: import.meta.url,
-          suffixes: ["/index"],
-          extensions: [".mjs"],
-        }),
-      );
-
-      const resolvedDriveLetter = path.match(DRIVE_LETTER_RE)![0];
-      expect(resolvedDriveLetter).toBe(driveLetter);
-    });
-  });
 });
 
 describe("resolveModulePath", () => {
@@ -144,6 +124,21 @@ describe("resolveModulePath", () => {
       }
     });
   }
+});
+
+describe.runIf(isWindows)("windows", () => {
+  it("normalizes drive letter and slashes", () => {
+    const resolved = resolveModulePath("./fixture/hello.mjs", {
+      from: import.meta.url,
+    });
+
+    expect(resolved).to.not.include("\\");
+    expect(resolved).to.include("/");
+
+    const DRIVE_LETTER_RE = /^\w(?=:)/;
+    const resolvedDriveLetter = resolved.match(DRIVE_LETTER_RE)![0];
+    expect(resolvedDriveLetter).toBe(resolvedDriveLetter.toUpperCase());
+  });
 });
 
 describe("normalized parent urls", () => {

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -128,16 +128,20 @@ describe("resolveModulePath", () => {
 
 describe.runIf(isWindows)("windows", () => {
   it("normalizes drive letter and slashes", () => {
-    const resolved = resolveModulePath("./fixture/hello.mjs", {
-      from: import.meta.url,
-    });
-
-    expect(resolved).to.not.include("\\");
-    expect(resolved).to.include("/");
-
-    const DRIVE_LETTER_RE = /^\w(?=:)/;
-    const resolvedDriveLetter = resolved.match(DRIVE_LETTER_RE)![0];
-    expect(resolvedDriveLetter).toBe(resolvedDriveLetter.toUpperCase());
+    for (const input of [
+      "./fixture/hello.mjs",
+      new URL("fixture/hello.mjs", import.meta.url),
+      new URL("fixture/hello.mjs", import.meta.url).href.toLowerCase(),
+    ]) {
+      const resolved = resolveModulePath(input, {
+        from: import.meta.url,
+      });
+      expect(resolved).to.not.include("\\");
+      expect(resolved).to.include("/");
+      const DRIVE_LETTER_RE = /^\w(?=:)/;
+      const resolvedDriveLetter = resolved.match(DRIVE_LETTER_RE)![0];
+      expect(resolvedDriveLetter).toBe(resolvedDriveLetter.toUpperCase());
+    }
   });
 });
 


### PR DESCRIPTION
`resolveModulePath` uses `fileURLToPath` from Node.js which uses backslashes however it is very common that we need to normalize slashes and might forget.

This PR normalizes windows slashes in absolute paths returned by `resolveModulePath` but only on windows to reduce extra processing on other platforms.