### PR TITLE
fix: correctly resolve extended `builtinModules`

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -349,7 +349,7 @@ function _parseInput(
       return { external: input };
     }
 
-    if (builtinModules.includes(input)) {
+    if (builtinModules.includes(input) && !input.includes(":")) {
       return { external: `node:${input}` };
     }
 

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { resolveModuleURL, resolveModulePath } from "../src";
 
 const isWindows = process.platform === "win32";
@@ -91,6 +91,20 @@ describe("resolveModuleURL", () => {
       },
     );
     expect(res).toMatch(/\.mjs$/);
+  });
+
+  it("resolve builtin modules", () => {
+    vi.mock("node:module", () => {
+      return {
+        builtinModules: ["fs", "path", "url", "http", "https", "bun:sqlite"],
+      };
+    });
+
+    expect(() => resolveModuleURL("unknown")).toThrowError();
+    expect(resolveModuleURL("node:fs")).toBe("node:fs");
+    expect(resolveModuleURL("fs")).toBe("node:fs");
+
+    expect(resolveModuleURL("bun:sqlite")).toBe("bun:sqlite");
   });
 });
 


### PR DESCRIPTION
Context: https://github.com/nitrojs/nitro/issues/3159

Bun runtime extends `node:module`'s `builtinModules` export with `bun:sqlite` (which is NOT a Node.js built-in module).

To avoid wrongly adding prefixes, this patch bypasses check for inputs already containing `:`