### PR TITLE
fix: keep a copy of node.js builtin modules

### DIFF
--- a/src/internal/builtins.ts
+++ b/src/internal/builtins.ts
@@ -1,0 +1,30 @@
+/*
+ * Extracted from Node.js v22.14.0
+ * For some reason, Bun decided to extend "node:modules" with bun specific modules which makes it unreliable source.
+ */
+// prettier-ignore
+export const nodeBuiltins = [
+    '_http_agent',         '_http_client',        '_http_common',
+    '_http_incoming',      '_http_outgoing',      '_http_server',
+    '_stream_duplex',      '_stream_passthrough', '_stream_readable',
+    '_stream_transform',   '_stream_wrap',        '_stream_writable',
+    '_tls_common',         '_tls_wrap',           'assert',
+    'assert/strict',       'async_hooks',         'buffer',
+    'child_process',       'cluster',             'console',
+    'constants',           'crypto',              'dgram',
+    'diagnostics_channel', 'dns',                 'dns/promises',
+    'domain',              'events',              'fs',
+    'fs/promises',         'http',                'http2',
+    'https',               'inspector',           'inspector/promises',
+    'module',              'net',                 'os',
+    'path',                'path/posix',          'path/win32',
+    'perf_hooks',          'process',             'punycode',
+    'querystring',         'readline',            'readline/promises',
+    'repl',                'stream',              'stream/consumers',
+    'stream/promises',     'stream/web',          'string_decoder',
+    'sys',                 'timers',              'timers/promises',
+    'tls',                 'trace_events',        'tty',
+    'url',                 'util',                'util/types',
+    'v8',                  'vm',                  'wasi',
+    'worker_threads',      'zlib'
+]

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,8 +1,8 @@
 import { statSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isAbsolute } from "node:path";
-import { builtinModules } from "node:module";
 import { moduleResolve } from "./internal/resolve.ts";
+import { nodeBuiltins } from "./internal/builtins.ts";
 
 const DEFAULT_CONDITIONS_SET = /* #__PURE__ */ new Set(["node", "import"]);
 
@@ -349,7 +349,7 @@ function _parseInput(
       return { external: input };
     }
 
-    if (builtinModules.includes(input)) {
+    if (nodeBuiltins.includes(input)) {
       return { external: `node:${input}` };
     }
 


### PR DESCRIPTION
resolves https://github.com/nitrojs/nitro/issues/3185

Extended fix from #16, Bun runtime decided to extend `node:module`, `builtinModules` with `bun`, and bunch of `bun:` prefixed exports, which makes Node.js built-in API an unreliable source!

Therefore we need to keep a copy of "real" Node.js builtin modules 🤷‍♂️