### PR TITLE
fix: resolve absolute symlinks to real paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Can be set to `false` to disable or a custom `Map` to bring your own cache objec
 
 See [cache](#resolve-cache) for more info.
 
+### `preserveSymlinks`
+
+Keep symlinks instead of resolving them. Default behavior is to resolve symlinks to their real paths.
+
+Can be set to `true` to disable resolving symlinks.
+
 ## Other Performance Tips
 
 **Use explicit module extensions `.mjs` or `.cjs` instead of `.js`:**

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -129,8 +129,11 @@ export function resolveModuleURL<O extends ResolveOptions>(
   if (absolutePath) {
     try {
       if (!options?.preserveSymlinks) {
-        absolutePath = realpathSync(absolutePath);
-        url = pathToFileURL(absolutePath);
+        const real = realpathSync(absolutePath);
+        if (real !== absolutePath) {
+          absolutePath = real;
+          url = pathToFileURL(real);
+        }
       }
 
       if (statSync(absolutePath).isFile()) {

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,4 +1,4 @@
-import { statSync } from "node:fs";
+import { realpathSync, statSync } from "node:fs";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { isAbsolute } from "node:path";
 import { moduleResolve } from "./internal/resolve.ts";
@@ -66,6 +66,12 @@ export type ResolveOptions = {
    * the resolver returns `undefined` instead of throwing an error.
    */
   try?: boolean;
+
+  /**
+   * Keep symlinks instead of resolving them.
+   * Default behavior is to resolve symlinks to their real paths.
+   */
+  preserveSymlinks?: boolean;
 };
 
 export type ResolverOptions = Omit<ResolveOptions, "try">;
@@ -92,8 +98,8 @@ export function resolveModuleURL<O extends ResolveOptions>(
   }
 
   const specifier = (parsedInput as { specifier: string }).specifier;
-  const url = (parsedInput as { url: URL }).url;
-  const absolutePath = (parsedInput as { absolutePath: string }).absolutePath;
+  let url = (parsedInput as { url: URL }).url;
+  let absolutePath = (parsedInput as { absolutePath: string }).absolutePath;
 
   // Check for cache
   let cacheKey: string | undefined;
@@ -122,6 +128,11 @@ export function resolveModuleURL<O extends ResolveOptions>(
   // Absolute path to file (fast path)
   if (absolutePath) {
     try {
+      if (!options?.preserveSymlinks) {
+        absolutePath = realpathSync(absolutePath);
+        url = pathToFileURL(absolutePath);
+      }
+
       if (statSync(absolutePath).isFile()) {
         if (cacheObj) {
           cacheObj.set(cacheKey!, url.href);

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { resolve as nodeResolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, it, expect, vi } from "vitest";
 import { resolveModuleURL, resolveModulePath } from "../src";
@@ -65,6 +66,13 @@ describe("resolveModuleURL", () => {
       from: import.meta.url,
     });
     expect(fileURLToPath(resolved2)).match(/fixture[/\\]test.txt$/);
+
+    const absolutePath = nodeResolve(
+      process.cwd(),
+      "./test/fixture/hello.link.mjs",
+    );
+    const resolved3 = resolveModuleURL(absolutePath);
+    expect(fileURLToPath(resolved3)).match(/fixture\/hello\.mjs$/);
   });
 
   it("resolves node built-ints", () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves https://github.com/unjs/exsolve/issues/21

Since Node.js's native `import.meta.resolve` resolves absolute paths to the realpath, `preserveSymlinks` defaults to `false` to match this behavior.