### PR TITLE
fix: resolve `.` with empty suffix

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -151,18 +151,19 @@ export function resolveModuleURL<O extends ResolveOptions>(
     : DEFAULT_CONDITIONS_SET;
 
   // Search through bases
+  const target = specifier || url.href;
   const bases: URL[] = _normalizeBases(options?.from);
   const suffixes = options?.suffixes || [""];
   const extensions = options?.extensions ? ["", ...options.extensions] : [""];
   let resolved: URL | undefined;
   for (const base of bases) {
     for (const suffix of suffixes) {
+      let name = _join(target, suffix);
+      if (name === ".") {
+        name += "/.";
+      }
       for (const extension of extensions) {
-        resolved = _tryModuleResolve(
-          _join(specifier || url.href, suffix) + extension,
-          base,
-          conditionsSet,
-        );
+        resolved = _tryModuleResolve(name + extension, base, conditionsSet);
         if (resolved) {
           break;
         }

--- a/test/fixture/foo/..txt
+++ b/test/fixture/foo/..txt
@@ -1,0 +1,1 @@
+Test file

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -101,6 +101,24 @@ describe("resolveModuleURL", () => {
     expect(res).toMatch(/\.mjs$/);
   });
 
+  it("should resolve `.` with empty suffix", () => {
+    const res = resolveModuleURL(".", {
+      from: new URL("fixture/foo/", import.meta.url).href,
+      suffixes: [""],
+      extensions: [".txt"],
+    });
+    expect(res).toMatch(/\.\.txt$/);
+  });
+
+  it("should resolve `.` with empty and additional suffixes", () => {
+    const res = resolveModuleURL(".", {
+      from: new URL("fixture/foo/", import.meta.url).href,
+      suffixes: ["", "/index"],
+      extensions: [".mjs"],
+    });
+    expect(res).toMatch(/index\.mjs$/);
+  });
+
   it("resolve builtin modules", () => {
     vi.mock("node:module", () => {
       return {


### PR DESCRIPTION
Resolving `"."` with empty suffix fails which can be an issue since using `["", "/index"]` is a great default setting for most libraries.

Error details:
```ts
// /utils/names.ts
import { QUOTE_RE } from '.' // from /utils/index.ts
```

```ts
const opts: ResolveOptions = {
  extensions: [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs", ".json"],
  suffixes: ["", "/index"],
};
```


```
TypeError: Invalid module "..tsx" is not a valid package name imported from /utils/names.ts
    at __node_internal_  exsolve/dist/index.mjs:159:9)
    at new NodeError  exsolve/dist/index.mjs:130:5)
    at parsePackageName  exsolve/dist/index.mjs:1097:11)
    at packageResolve  exsolve/dist/index.mjs:1110:53)
    at moduleResolve  exsolve/dist/index.mjs:1196:18)
    at _tryModuleResolve  exsolve/dist/index.mjs:1348:12)
    at resolveModuleURL  exsolve/dist/index.mjs:1275:20)
    at resolveModulePath  exsolve/dist/index.mjs:1311:20)
  code: 'ERR_INVALID_MODULE_SPECIFIER'
}
```

Added failing test cases and a fix.