### PR TITLE
fix: match wildcard `imports` keys with a trailer

### DIFF
--- a/src/internal/resolve.ts
+++ b/src/internal/resolve.ts
@@ -699,7 +699,7 @@ function packageImportsResolve(name: string, base: URL, conditions?: Set<string>
           const key = keys[i]!;
           const patternIndex = key.indexOf("*");
 
-          if (patternIndex !== -1 && name.startsWith(key.slice(0, -1))) {
+          if (patternIndex !== -1 && name.startsWith(key.slice(0, patternIndex))) {
             const patternTrailer = key.slice(patternIndex + 1);
             if (
               name.length >= key.length &&

--- a/test/fixture/imports-pkg/feat-any/x.js
+++ b/test/fixture/imports-pkg/feat-any/x.js
@@ -1,0 +1,1 @@
+export const via = "feat-any";

--- a/test/fixture/imports-pkg/feat-js/x.js
+++ b/test/fixture/imports-pkg/feat-js/x.js
@@ -1,0 +1,1 @@
+export const via = "feat-js";

--- a/test/fixture/imports-pkg/lib/deep/thing.js
+++ b/test/fixture/imports-pkg/lib/deep/thing.js
@@ -1,0 +1,1 @@
+export const thing = "lib/deep/thing.js";

--- a/test/fixture/imports-pkg/package.json
+++ b/test/fixture/imports-pkg/package.json
@@ -2,6 +2,10 @@
   "name": "imports-pkg",
   "imports": {
     "#/*": "./src/*",
-    "#internal": "./internal.js"
+    "#internal": "./internal.js",
+    "#*.js": "./runtime/*.js",
+    "#lib/*.js": "./lib/*.js",
+    "#feat*.js": "./feat-js/*.js",
+    "#feat*": "./feat-any/*"
   }
 }

--- a/test/fixture/imports-pkg/runtime/internal/marker.js
+++ b/test/fixture/imports-pkg/runtime/internal/marker.js
@@ -1,0 +1,1 @@
+export const marker = "runtime/internal/marker.js";

--- a/test/resolve-imports-exports.test.ts
+++ b/test/resolve-imports-exports.test.ts
@@ -24,6 +24,38 @@ describe("package.json imports field", () => {
     expect(resolved).toMatch(/imports-pkg\/internal\.js$/);
     expect(existsSync(fileURLToPath(resolved))).toBe(true);
   });
+
+  // Regression (#56): the pattern base was computed as `key.slice(0, -1)`
+  // instead of `key.slice(0, patternIndex)`, so any wildcard key with a
+  // trailer (`#*.js`) was tested against `name.startsWith("#*.")` and could
+  // never match. Keys without a trailer (`#/*`) happened to work, which hid
+  // the bug. `exports` resolution already used the correct base.
+  it("resolves a wildcard import key with a trailer", () => {
+    const resolved = resolveModuleURL("#internal/marker.js", { from });
+    expect(resolved).toMatch(/imports-pkg\/runtime\/internal\/marker\.js$/);
+    expect(existsSync(fileURLToPath(resolved))).toBe(true);
+  });
+
+  it("resolves a nested wildcard import key with a trailer", () => {
+    const resolved = resolveModuleURL("#lib/deep/thing.js", { from });
+    expect(resolved).toMatch(/imports-pkg\/lib\/deep\/thing\.js$/);
+    expect(existsSync(fileURLToPath(resolved))).toBe(true);
+  });
+
+  // The same bug could also resolve the *wrong* file rather than throw: when
+  // `#feat*.js` was skipped, the less specific `#feat*` won by default and
+  // `feat-any/x.js` was loaded instead. Both targets exist, so this pins key
+  // selection (`patternKeyCompare`) and not mere existence.
+  it("prefers the more specific key when wildcard keys compete", () => {
+    const resolved = resolveModuleURL("#featx.js", { from });
+    expect(resolved).toMatch(/imports-pkg\/feat-js\/x\.js$/);
+    expect(resolved).not.toMatch(/feat-any/);
+  });
+
+  // Boundary: `name.length >= key.length` fails, so `#*.js` must not match.
+  it("does not match a wildcard key when the specifier is too short", () => {
+    expect(() => resolveModuleURL("#.js", { from })).toThrow();
+  });
 });
 
 describe("package.json conditional exports fall-through", () => {


### PR DESCRIPTION
Fixes #56.

### Problem

`packageImportsResolve` computed the wildcard pattern base as `key.slice(0, -1)` instead of `key.slice(0, patternIndex)`. For a key like `#*.js` this tested `name.startsWith("#*.")`, which never matches, so the key was skipped.

Usually that meant resolution threw — but when a less specific key also matched, it **silently resolved the wrong file**. Given `#feat*.js` and `#feat*`, `patternKeyCompare` should pick the former for `#featx.js`; instead the former was skipped and the latter won by default.

Keys *without* a trailer (`#/*`) were unaffected — `slice(0, -1)` and `slice(0, patternIndex)` coincide there — which is why this went unnoticed. `packageExportsResolve` already used the correct base, so `exports` and `imports` disagreed within the same file.

### Changes

- `src/internal/resolve.ts` — one-line fix, aligning with the [Node.js upstream implementation](https://github.com/nodejs/node/blob/main/lib/internal/modules/esm/resolve.js).
- `test/resolve-imports-exports.test.ts` — regression tests for a bare wildcard-with-trailer key, a nested one, and the wrong-winner case above (both targets exist on disk, so it pins key selection rather than mere existence), plus a negative test that `#.js` still does not match `#*.js`.

The three positive tests fail on the parent commit and pass with the fix. Because `key.slice(0, patternIndex)` is always a prefix of `key.slice(0, -1)`, the new predicate is a strict superset of the old one — it can only add matches, never remove them.

### Verification

Full suite passes (84 passed, 1 skipped), as do `tsc --noEmit`, `oxlint`, and `oxfmt --check`.

The fixture in `test/fixture/imports-pkg` was also checked against real Node (`createRequire().resolve`, v24.18.0) to confirm the expectations are Node's actual answers and that the added keys don't disturb the pre-existing cases:

| specifier | Node |
| --- | --- |
| `#internal/marker.js` | `runtime/internal/marker.js` |
| `#lib/deep/thing.js` | `lib/deep/thing.js` |
| `#featx.js` | `feat-js/x.js` |
| `#.js` | `ERR_PACKAGE_IMPORT_NOT_DEFINED` |
| `#/util.js` | `src/util.js` (unchanged) |
| `#internal` | `internal.js` (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)